### PR TITLE
refactor(layout): move header from page to layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { EB_Garamond, Inter } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { Providers } from "./providers";
+import { Header } from "@/components/header";
 
 export const metadata: Metadata = {
   title: "Wikipedia Semantic Search by Upstash Vector",
@@ -15,7 +16,7 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-	maximumScale: 1, // Disable auto-zoom on mobile Safari
+  maximumScale: 1, // Disable auto-zoom on mobile Safari
 };
 
 const serif = EB_Garamond({
@@ -51,6 +52,7 @@ export default async function RootLayout({
       <body className="antialiased text-sm sm:text-base text-yellow-950 min-h-screen bg-white">
         <Providers>
           <NextIntlClientProvider messages={messages}>
+            <Header />
             {children}
           </NextIntlClientProvider>
         </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,33 +16,29 @@ export default function Page() {
   const [tab, setTab] = useState<"chat" | "search">("search");
 
   return (
-    <>
-      <Header />
+    <main>
+      <Tabs
+        value={tab}
+        onValueChange={(value) => setTab(value as "chat" | "search")}
+      >
+        <TabsList className="block">
+          <Container>
+            <TabsTrigger value="search">Search</TabsTrigger>
+            <TabsTrigger value="chat">Chat to Wikipedia</TabsTrigger>
+          </Container>
+        </TabsList>
 
-      <main>
-        <Tabs
-          value={tab}
-          onValueChange={(value) => setTab(value as "chat" | "search")}
-        >
-          <TabsList className="block">
-            <Container>
-              <TabsTrigger value="search">Search</TabsTrigger>
-              <TabsTrigger value="chat">Chat to Wikipedia</TabsTrigger>
-            </Container>
-          </TabsList>
-
-          <TabsContent value="search" className="">
-            <Container className="py-6 sm:py-8">
-              <SearchTab />
-            </Container>
-          </TabsContent>
-          <TabsContent value="chat">
-            <Container className="py-6 sm:py-8">
-              <ChatTab />
-            </Container>
-          </TabsContent>
-        </Tabs>
-      </main>
-    </>
+        <TabsContent value="search" className="">
+          <Container className="py-6 sm:py-8">
+            <SearchTab />
+          </Container>
+        </TabsContent>
+        <TabsContent value="chat">
+          <Container className="py-6 sm:py-8">
+            <ChatTab />
+          </Container>
+        </TabsContent>
+      </Tabs>
+    </main>
   );
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useRouter } from "next/navigation";
 import Container from "@/components/container";
 


### PR DESCRIPTION
Hi!

I noticed that the `Header` component is being used on the `index` page, but since it's not specific to this page, I moved it to `layout.tsx`.